### PR TITLE
More robust deed dice/attack bonus handling

### DIFF
--- a/scripts/dcc-qol.js
+++ b/scripts/dcc-qol.js
@@ -6,14 +6,30 @@ export async function preloadTemplates () {
   const templatePaths = ['modules/dcc-qol/templates/attackroll-card.html']
   return loadTemplates(templatePaths)
 }
-function tokenForActorId (tokenUuid) {
-  const position = tokenUuid.indexOf('.Actor.')
-  if (position === -1) { return undefined } else { return fromUuidSync(tokenUuid.substr(0, position)) }
+// function tokenForActorId (tokenUuid) {
+//   const position = tokenUuid.indexOf('.Actor.')
+//   if (position === -1) { return undefined } else { return fromUuidSync(tokenUuid.substr(0, position)) }
+// }
+
+function tokenForActorId (actorId) {
+  const actor = game.actors.get(actorId)
+  const allTokens = actor.getActiveTokens()
+  if (allTokens.length === 1) return allTokens[0].document
+  else {
+    const controlled = canvas?.tokens?.controlled
+    const filteredTokens = allTokens.filter((value) =>
+      controlled.includes(value)
+    )
+    if (filteredTokens.length === 1) return filteredTokens[0].document
+    else {
+      return undefined
+    }
+  }
 }
 
 function rollPatchedWeaponAttack (wrapped, ...args) {
   const actor = new DCCQOL(this)
-  const tokenD = tokenForActorId(this.uuid)
+  const tokenD = tokenForActorId(this._id)
   // if settings are set to checkWeaponRange, or automateFriendlyFire, require a token to be in scene; otherwise, proceed without one
   if (
     game.settings.get('dcc-qol', 'checkWeaponRange') ||

--- a/scripts/patch.js
+++ b/scripts/patch.js
@@ -487,6 +487,7 @@ class DCCQOL extends Actor {
 
     /* If we don't have a valid formula, bail out here */
     if (!(await Roll.validate(toHit))) {
+    console.warn('DCC-QOL | Invalid toHit formula:', toHit);
       return {
         rolled: false,
         formula: weapon.system.toHit
@@ -508,6 +509,7 @@ class DCCQOL extends Actor {
     /* Remove empty toHit value from RollFormula */
     if (Number(toHit) !== 0 || options.showModifierDialog) {
       const newToHit = toHit.replace('+@ab', '')
+
       if (newToHit.length !== 0) debuginfo = debuginfo + `[ToHit:${newToHit}]`
       terms.push({
         type: 'Compound',
@@ -525,8 +527,12 @@ class DCCQOL extends Actor {
     ) {
       const index = terms.findIndex((element) => element.type === 'Compound')
       if (index !== -1) {
-        const deedDie = this.system.details.attackBonus.replace(/\+1?/i, '') // previously was replacing with 1
-        terms[index].formula = terms[index].formula.replace('+@ab', deedDie)
+        // console.warn('DCC-QOL | attackBonus:', this.system.details.attackBonus)
+        const deedDie = this.system.details.attackBonus.replace(/\+1?/i, '1') 
+        // console.warn('DCC-QOL | deedDie:', deedDie);
+        // console.warn('DCC-QOL | terms[index].formula:', terms[index].formula)
+        terms[index].formula = terms[index].formula.replace('@ab', deedDie)
+        // console.warn('DCC-QOL | new terms[index].formula:', terms[index].formula);
       }
     }
 

--- a/scripts/patch.js
+++ b/scripts/patch.js
@@ -276,9 +276,8 @@ class DCCQOL extends Actor {
         DCCActor.system.details.sheetClass === 'Dwarf') &&
       game.settings.get('dcc-qol', 'automateDeedDieRoll')
     ) {
-      const deedDieFace = Number(
-        this.system.details.attackBonus.replace(/\+1?d/, '')
-      )
+      const deedDieFace = extractDieValue(this.system.details.attackBonus);
+      // console.warn('DCC-QOL | deedDieFace:', deedDieFace)
       if (weapon.system.toHit.includes('@ab')) {
         lastDeedRoll = attackRollResult.roll.terms.find(
           (element) => element.faces === deedDieFace
@@ -527,12 +526,11 @@ class DCCQOL extends Actor {
     ) {
       const index = terms.findIndex((element) => element.type === 'Compound')
       if (index !== -1) {
-        // console.warn('DCC-QOL | attackBonus:', this.system.details.attackBonus)
         const deedDie = this.system.details.attackBonus.replace(/\+1?/i, '1') 
         // console.warn('DCC-QOL | deedDie:', deedDie);
         // console.warn('DCC-QOL | terms[index].formula:', terms[index].formula)
         terms[index].formula = terms[index].formula.replace('@ab', deedDie)
-        // console.warn('DCC-QOL | new terms[index].formula:', terms[index].formula);
+        // console.warn('DCC-QOL | revised terms[index].formula:', terms[index].formula);
       }
     } 
 
@@ -696,6 +694,17 @@ class DCCQOL extends Actor {
       fumble,
       firingIntoMelee
     }
+  }
+}
+function extractDieValue(diceString) {
+  // Regular expression to match the dice notation including optional modifiers
+  const pattern = /\d*d(\d+)[+-]?/;
+
+  const match = diceString.match(pattern);
+  if (match) {
+    return parseInt(match[1], 10); // Return the captured die value as an integer
+  } else {
+    return null; // Return null if no valid die notation is found
   }
 }
 

--- a/scripts/patch.js
+++ b/scripts/patch.js
@@ -277,9 +277,9 @@ class DCCQOL extends Actor {
       game.settings.get('dcc-qol', 'automateDeedDieRoll')
     ) {
       const deedDieFace = Number(
-        this.system.details.attackBonus.replace('+d', '')
+        this.system.details.attackBonus.replace(/\+1?d/, '')
       )
-      if (weapon.system.toHit.includes('+@ab')) {
+      if (weapon.system.toHit.includes('@ab')) {
         lastDeedRoll = attackRollResult.roll.terms.find(
           (element) => element.faces === deedDieFace
         ).results[0].result
@@ -297,7 +297,7 @@ class DCCQOL extends Actor {
         }
       } else {
         console.warn(
-          'DCC-QOL | Missing "+@ab" in toHit. Dice So Nice cannot display deed die roll.: ' + weapon.system.toHit 
+          'DCC-QOL | Missing "@ab" in "To Hit" bonus on weapon ('+ weapon.system.toHit+'), so deed roll/attack bonus is not included.'  
         )
       }
     }
@@ -534,7 +534,7 @@ class DCCQOL extends Actor {
         terms[index].formula = terms[index].formula.replace('@ab', deedDie)
         // console.warn('DCC-QOL | new terms[index].formula:', terms[index].formula);
       }
-    }
+    } 
 
     // Add backstab bonus if required
     if (options.backstab) {


### PR DESCRIPTION
Resolved issues with deed dice/attack bonus handling. Tested the following permutations:

Attack Bonus: +1, +1d3, +d3

Weapon "To Hit": +1+@ab, +@ab, @ab, +@ab+1, 1+@ab+1

Also reverted the tokenForActorId function since the new version wasn't working correctly for me. 